### PR TITLE
Unit report of bug

### DIFF
--- a/test/unittests/test_helpers.cpp
+++ b/test/unittests/test_helpers.cpp
@@ -33,6 +33,7 @@ TEST(helpers, release_result)
 
     static evmc_result r2;
     static bool e;
+    static r1;
 
     e = false;
     r2 = evmc_result{};


### PR DESCRIPTION
well the struct of r1 is missing as per the vector definition and condone which was also letting the false true values into the system that has been enabled for the smog variable and collaboration false input expected .